### PR TITLE
CVSL-337: Update spring boot plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.0.0"
-  kotlin("plugin.spring") version "1.6.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.0.1"
+  kotlin("plugin.spring") version "1.6.10"
 }
 
 configurations {


### PR DESCRIPTION
The project has been failing overnight owasp / trivy scans.
Updating the gradle springboot plugin from `4.0.0` to `4.0.1` sorts these.