### PR TITLE
Remove "live1" cluster references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ see https://github.com/ministryofjustice/dps-project-bootstrap.
 
 When deploying to a new namespace, you may wish to use this template kotlin project namespace as the basis for your new namespace:
 
-<https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-template-kotlin>
+<https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-kotlin>
 
 Copy this folder, update all the existing namespace references, and submit a PR to the CloudPlatform team. Further instructions from the CloudPlatform team can be found here: <https://user-guide.cloud-platform.service.justice.gov.uk/#cloud-platform-user-guide>
 

--- a/helm_deploy/hmpps-template-kotlin/values.yaml
+++ b/helm_deploy/hmpps-template-kotlin/values.yaml
@@ -35,9 +35,9 @@ generic-service:
     office: "217.33.148.210/32"
     health-kick: "35.177.252.195/32"
     mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
+    cloudplatform-live-1: "35.178.209.113/32"
+    cloudplatform-live-2: "3.8.51.207/32"
+    cloudplatform-live-3: "35.177.252.54/32"
 
 generic-prometheus-alerts:
   targetApplication: hmpps-template-kotlin


### PR DESCRIPTION
The IPs for the live1 and live clusters are all the same:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/ip-filtering.html#live-cluster

However, it's a bit misleading to reference the old cluster, hence this
change