### PR TITLE
⚡️ Always run server-class JVMs inside our containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /
 
 USER 2000
 
-ENTRYPOINT ["java", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-XX:+AlwaysActAsServerClassMachine", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]


### PR DESCRIPTION
In the default cloud-platform-environments configuration, we have 1GB memory allocated to each pod.

Since JDK 10, this fails the criteria of "server class machine", so the JVM starts with the **serial garbage collector**. (Server class is defined as ">= 2 physical CPU's and >=2GB of memory")

**The serial GC is a "stop-the-world" garbage collector and so creates unnecessary pauses in production.**

The effect of `-XX:+AlwaysActAsServerClassMachine` is that the default GC will be the server-class GC (G1 GC in most cases).

References:
- https://github.com/openjdk/jdk/blob/jdk-17%2B35/src/hotspot/share/runtime/os.cpp#L1674-L1675
- https://stackoverflow.com/a/52477898/621923

Pulls in changes done in:
- https://github.com/ministryofjustice/hmpps-interventions-service/pull/852