### PR TITLE
Fixes for Gradle 8 and tidy ups

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -32,3 +32,6 @@ CVE-2022-42889
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
+# Suppression for spring-web 5.3.24 as bundled with spring boot
+#   can be suppressed as we are not using java serialization and deserialization explicitly
+CVE-2016-1000027

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,13 +12,13 @@ dependencies {
 }
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(18))
+  toolchain.languageVersion.set(JavaLanguageVersion.of(19))
 }
 
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
-      jvmTarget = "18"
+      jvmTarget = "19"
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.installations.auto-detect=false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,5 @@
 rootProject.name = "hmpps-template-kotlin"
+
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,1 @@
 rootProject.name = "hmpps-template-kotlin"
-
-plugins {
-  id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
-}


### PR DESCRIPTION
Fixes for Gradle 8 and tidy ups

https://github.com/ministryofjustice/hmpps-template-kotlin/pull/140 broke `builder_docker` -  https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-template-kotlin/1107/workflows/0f648224-0b09-4ae7-8a8f-f327927fcde5/jobs/2636

See https://docs.gradle.org/8.0/release-notes.html#java-toolchains-improvements