### PR TITLE
Use Kotlin 1.8.10 to match the DPS Spring Boot Gradle Plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.5"
-  kotlin("plugin.spring") version "1.8.20"
+  kotlin("plugin.spring") version "1.8.10"
 }
 
 configurations {


### PR DESCRIPTION
See https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/release-notes/4.8.6.md#attempted-upgrade-to-kotlin-1820 for issues with Kotlin 1.8.20