### PR TITLE
fix: remove workflow modifications from rename script

### DIFF
--- a/rename-project.bash
+++ b/rename-project.bash
@@ -90,11 +90,18 @@ sed -i -z -E \
   -e "s/SLACK_RELEASES_CHANNEL/$SLACK_RELEASES_CHANNEL/" \
   .circleci/config.yml
 
-sed -i -z -E \
-  -e "s/on:\n  workflow_dispatch:\n  schedule:\n    - cron: \"19 6/on:\n  workflow_dispatch:\n  schedule:\n    - cron: \"$RANDOM_MINUTE $RANDOM_HOUR/" \
-  -e "s/on:\n  workflow_dispatch:\n  schedule:\n    - cron: \"34 6/on:\n  workflow_dispatch:\n  schedule:\n    - cron: \"$RANDOM_MINUTE2 $RANDOM_HOUR/" \
-  -e "s/C05J915DX0Q/$SECURITY_ALERTS_SLACK_CHANNEL_ID/" \
-  .github/workflows/*
+echo "NEEDS TO BE SET MANUALLY"
+echo "========================"
+echo "DAILY CRON:    ${RANDOM_MINUTE} ${RANDOM_HOUR}"
+echo "WEEKLY CRON:   ${RANDOM_MINUTE2} ${RANDOM_HOUR}"
+echo "SLACK CHANNEL: ${SECURITY_ALERTS_SLACK_CHANNEL_ID}"
+
+# TEMPORARILY REMOVED - THIS WILL NEED TO BE DONE MANUALLY UNTIL WE MOVE TO GITHUB ACTIONS BOOTSTRAP
+# sed -i -z -E \
+#   -e "s/on:\n  workflow_dispatch:\n  schedule:\n    - cron: \"19 6/on:\n  workflow_dispatch:\n  schedule:\n    - cron: \"$RANDOM_MINUTE $RANDOM_HOUR/" \
+#   -e "s/on:\n  workflow_dispatch:\n  schedule:\n    - cron: \"34 6/on:\n  workflow_dispatch:\n  schedule:\n    - cron: \"$RANDOM_MINUTE2 $RANDOM_HOUR/" \
+#   -e "s/C05J915DX0Q/$SECURITY_ALERTS_SLACK_CHANNEL_ID/" \
+#   .github/workflows/*
 
 # lastly remove ourselves
 rm rename-project.bash


### PR DESCRIPTION
This will ensure the rename process works - a separate PR will be needed to change the schedule manually.