### PR TITLE
SECURIT_ALERTS_SLACK_CHANNEL_ID for security workflows

### DIFF
--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -8,5 +8,5 @@ jobs:
     name: Kotlin security OWASP dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_owasp.yml@v2 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security trivy dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_trivy.yml@v2 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security veracode pipeline scan
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@v2 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security veracode policy scan
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@v2 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit


### PR DESCRIPTION
swap out the baked-in channel to the environment variable (bootstrap will be updated in another PR) 