### PR TITLE
SDIT-2788: 🔧 Default multi platform to false

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,7 +52,7 @@ jobs:
       registry_org: 'ministryofjustice'
       additional_docker_tag: ${{ inputs.additional_docker_tag }}
       push: ${{ inputs.push || true }}
-      docker_multiplatform: true
+      docker_multiplatform: false
   deploy_dev:
     name: Deploy to the development environment
     needs:


### PR DESCRIPTION
Having it set to `true` is useful if people are running the image locally.
However the vast majority of our images are never run locally and thus consume double the amount of storage space and take double the amount of computing power to build.  Therefore, for the purposes of green computing, it would be better to set the default to `false` and people can enable in their repos if required.