### PR TITLE
Prevent flakiness in openapi test when test runs on different date to the build date fixed in the version

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/templatepackagename/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/templatepackagename/integration/OpenApiDocsTest.kt
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.info.BuildProperties
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.MediaType
 import java.time.LocalDate
@@ -15,6 +17,9 @@ import java.time.format.DateTimeFormatter
 class OpenApiDocsTest : IntegrationTestBase() {
   @LocalServerPort
   private val port: Int = 0
+
+  @Autowired
+  private lateinit var buildProperties: BuildProperties
 
   @Test
   fun `open api docs are available`() {
@@ -71,7 +76,7 @@ class OpenApiDocsTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
       .expectBody().jsonPath("info.version").value<String> {
-        assertThat(it).startsWith(DateTimeFormatter.ISO_DATE.format(LocalDate.now()))
+        assertThat(it).isEqualTo(buildProperties.version)
       }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/templatepackagename/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/templatepackagename/integration/OpenApiDocsTest.kt
@@ -11,8 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.info.BuildProperties
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.MediaType
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 class OpenApiDocsTest : IntegrationTestBase() {
   @LocalServerPort


### PR DESCRIPTION
Found an issue which can cause flakiness in one of the open api integration tests. 

the test in question assumes that the build artifact was generated on the same day as the tests are run. This is accurate in most cases, but not assured. There are scenarios where you might be running the tests against an artifact built earlier. For example, if the pipeline runs, the build is successful, but a test fails, if you re-run "failed jobs" only a day later, this test will fail because the test date and the date in the build version will be out by 1 day. 