### PR TITLE
Prevent flakiness in InfoPage version test

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/templatepackagename/integration/health/InfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/templatepackagename/integration/health/InfoTest.kt
@@ -2,11 +2,14 @@ package uk.gov.justice.digital.hmpps.templatepackagename.integration.health
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.info.BuildProperties
 import uk.gov.justice.digital.hmpps.templatepackagename.integration.IntegrationTestBase
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 class InfoTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var buildProperties: BuildProperties
 
   @Test
   fun `Info page is accessible`() {
@@ -25,7 +28,7 @@ class InfoTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
       .expectBody().jsonPath("build.version").value<String> {
-        assertThat(it).startsWith(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
+        assertThat(it).isEqualTo(buildProperties.version)
       }
   }
 }


### PR DESCRIPTION
Same situation as for https://github.com/ministryofjustice/hmpps-prisoner-pay-orchestrator-api/pull/74 

but found another instance of that pattern in the info Page. 