### PR TITLE
Add egress proxy configuration to default Helm values

### DIFF
--- a/helm_deploy/hmpps-template-kotlin/values.yaml
+++ b/helm_deploy/hmpps-template-kotlin/values.yaml
@@ -18,16 +18,20 @@ generic-service:
   env:
     SERVER_PORT: "8080"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
+    APPLICATIONINSIGHTS_STATSBEAT_DISABLED: "true" # Disable Application Insights statsbeat telemetry
     # JAVA_TOOL_OPTIONS is set in the base image (hmpps-eclipse-temurin) with:
     #   -XX:MaxRAMPercentage=50.0
     # Uncomment below to override memory settings if needed.
+    # When using proxy, merge $(JAVA_PROXY_TOOL_OPTIONS) with your settings:
+    #   JAVA_TOOL_OPTIONS: "$(JAVA_PROXY_TOOL_OPTIONS) -XX:MaxRAMPercentage=75.0"
+    #
     # Check resources.limits.memory is set appropriately.
     #
     # Percentage-based example:
-    #   JAVA_TOOL_OPTIONS: "-XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=75.0"
+    #   JAVA_TOOL_OPTIONS: "$(JAVA_PROXY_TOOL_OPTIONS) -XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=75.0"
     #
     # Fixed memory example:
-    #   JAVA_TOOL_OPTIONS: "-Xms512m -Xmx1024m"
+    #   JAVA_TOOL_OPTIONS: "$(JAVA_PROXY_TOOL_OPTIONS) -Xms512m -Xmx1024m"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -37,6 +41,17 @@ generic-service:
   namespace_secrets:
     hmpps-template-kotlin-application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
+    # Uncomment the section below when your namespace has egress controls deployed.
+    # This is required for services to route outbound HTTPS traffic through the Envoy proxy.
+    # See: https://tech-docs.hmpps.service.justice.gov.uk/service-standard/egress-controls
+    # hmpps-envoy-https-proxy-env:
+    #   HTTP_PROXY: "HTTP_PROXY"
+    #   HTTPS_PROXY: "HTTPS_PROXY"
+    #   NO_PROXY: "NO_PROXY"
+    #   http_proxy: "HTTP_PROXY"
+    #   https_proxy: "HTTPS_PROXY"
+    #   no_proxy: "NO_PROXY"
+    #   JAVA_PROXY_TOOL_OPTIONS: "JAVA_PROXY_TOOL_OPTIONS"
 
   allowlist:
     groups:


### PR DESCRIPTION
## Part of Egress Controls Rollout

**Related PRs:**
- **Namespace config**: https://github.com/ministryofjustice/cloud-platform-environments/pull/43251
- **TypeScript template**: https://github.com/ministryofjustice/hmpps-template-typescript/pull/767

## Summary

Adds proxy configuration to default Helm values, **commented out by default** to avoid breaking deployments in namespaces without egress controls.

## Changes

### Environment Variables
- Add `APPLICATIONINSIGHTS_STATSBEAT_DISABLED=true` to disable statsbeat telemetry

This is the official Application Insights Java Agent 3.x environment variable for disabling statsbeat. Statsbeat sends internal telemetry about the agent itself to Microsoft. We disable it because:
- It's not essential for application monitoring
- Statsbeat endpoint domains could change without notice
- Reduces potential proxy compatibility issues

### Documentation
Updated `JAVA_TOOL_OPTIONS` examples to show how to merge with `$(JAVA_PROXY_TOOL_OPTIONS)`:
```yaml
JAVA_TOOL_OPTIONS: "$(JAVA_PROXY_TOOL_OPTIONS) -XX:MaxRAMPercentage=75.0"
```

### Namespace Secrets (commented out)
Proxy secret configuration is included but **commented out by default**:
```yaml
# Uncomment the section below when your namespace has egress controls deployed.
# hmpps-envoy-https-proxy-env:
#   HTTP_PROXY: "HTTP_PROXY"
#   HTTPS_PROXY: "HTTPS_PROXY"
#   NO_PROXY: "NO_PROXY"
#   JAVA_PROXY_TOOL_OPTIONS: "JAVA_PROXY_TOOL_OPTIONS"
#   ...
```

## Why Commented by Default?

This approach:
- ✅ Works for both **new namespaces** (with egress controls) and **existing namespaces** (without)
- ✅ Acts as a prompt for teams to deploy egress controls
- ✅ Prevents pod startup failures when secret doesn't exist
- ✅ Simple opt-in: uncomment when egress controls are deployed

## Compatibility

Works with:
- `hmpps-kotlin-spring-boot-starter` **2.3.0+**

This version automatically configures:
- WebClient helpers to use proxy settings
- OAuth2 client-credentials token acquisition via proxy

## Usage

1. **For new namespaces created from template**: Uncomment immediately (egress controls deployed by default)
2. **For services in existing namespaces**: 
   - Deploy egress controls to namespace first
   - Then uncomment proxy secret configuration
   - See: https://tech-docs.hmpps.service.justice.gov.uk/service-standard/egress-controls