### PR TITLE
Break out allowlists into separate categories

### DIFF
--- a/helm_deploy/hmpps-template-kotlin/values.yaml
+++ b/helm_deploy/hmpps-template-kotlin/values.yaml
@@ -38,9 +38,5 @@ generic-service:
     hmpps-template-kotlin-application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
 
-  allowlist:
-    groups:
-      - internal
-
 generic-prometheus-alerts:
   targetApplication: hmpps-template-kotlin

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,6 +16,12 @@ generic-service:
   scheduledDowntime:
     enabled: true
 
+  allowlist:
+    groups:
+      - digital_staff_and_mojo
+      - moj_cloud_platform
+
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,6 +6,7 @@ generic-service:
 
   ingress:
     host: template-kotlin-dev.hmpps.service.justice.gov.uk
+    # modsecurity_enabled: true
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
@@ -15,11 +16,22 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
-
+    
+    # Configure groups as appropriate to give the minimum ingress access required:
+    #   digital_staff_and_mojo: devices on the MoJ network
+    #   moj_cloud_platform: services on Cloud Platform
+    # Other IP allowlist groups are here: 
+    # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
   allowlist:
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform
+
+  # NOTE: Removing ALL allowlist groups will make the application accessible from the internet. 
+  #       If you are intending to do this, please ensure you uncomment the 'modsecurity_enabled=true' 
+  #       entry in the ingress above. This will enable WAF protection of the endpoint. You will need 
+  #       to configure modsecurity rules to suit your needs. Further information can be found here:
+  #       https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#modsecurity-web-application-firewall
 
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -19,13 +19,13 @@ generic-service:
 
   allowlist:
     # Configure groups as appropriate to give the minimum ingress access required:
-    #   digital_staff_and_mojo: devices on the MoJ network
+    #   global_protect: devices using the global_protect proxy
     #   moj_cloud_platform: services on Cloud Platform
     # Other IP allowlist groups are here: 
     # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
 
     groups:
-      - digital_staff_and_mojo
+      - global_protect
       - moj_cloud_platform
 
   # NOTE: Removing ALL allowlist groups will make the application accessible from the internet. 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -6,6 +6,7 @@ generic-service:
 
   ingress:
     host: template-kotlin-preprod.hmpps.service.justice.gov.uk
+    # modsecurity_enabled: true
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
@@ -14,13 +15,25 @@ generic-service:
   scheduledDowntime:
     enabled: true
 
+
+
   allowlist:
-    # remove groups as appropriate to give the minimum ingress access required:
+    # Configure groups as appropriate to give the minimum ingress access required:
     #   digital_staff_and_mojo: devices on the MoJ network
     #   moj_cloud_platform: services on Cloud Platform
+    # Other IP allowlist groups are here: 
+    # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
+
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform
+
+  # NOTE: Removing ALL allowlist groups will make the application accessible from the internet. 
+  #       If you are intending to do this, please ensure you uncomment the 'modsecurity_enabled=true' 
+  #       entry in the ingress above. This will enable WAF protection of the endpoint. You will need 
+  #       to configure modsecurity rules to suit your needs. Further information can be found here:
+  #       https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#modsecurity-web-application-firewall
+
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,7 +15,7 @@ generic-service:
     enabled: true
 
   allowlist:
-    # remove groups as appropriate to give the minimum access required:
+    # remove groups as appropriate to give the minimum ingress access required:
     #   digital_staff_and_mojo: devices on the MoJ network
     #   moj_cloud_platform: services on Cloud Platform
     groups:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,7 +15,9 @@ generic-service:
     enabled: true
 
   allowlist:
-    # modify these to give the least access required
+    # remove groups as appropriate to give the minimum access required:
+    #   digital_staff_and_mojo: devices on the MoJ network
+    #   moj_cloud_platform: services on Cloud Platform
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,6 +15,7 @@ generic-service:
     enabled: true
 
   allowlist:
+    # modify these to give the least access required
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,6 +14,11 @@ generic-service:
   scheduledDowntime:
     enabled: true
 
+  allowlist:
+    groups:
+      - digital_staff_and_mojo
+      - moj_cloud_platform
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,6 +8,12 @@ generic-service:
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
 
+  allowlist:
+    groups:
+      - digital_staff_and_mojo
+      - moj_cloud_platform
+
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,6 +9,7 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
 
   allowlist:
+    # modify these to give the least access required
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,13 +11,13 @@ generic-service:
  
   allowlist:
     # Configure groups as appropriate to give the minimum ingress access required:
-    #   digital_staff_and_mojo: devices on the MoJ network
+    #   global_protect: devices using the global_protect proxy
     #   moj_cloud_platform: services on Cloud Platform
     # Other IP allowlist groups are here: 
     # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
 
     groups:
-      - digital_staff_and_mojo
+      - global_protect
       - moj_cloud_platform
 
   # NOTE: Removing ALL allowlist groups will make the application accessible from the internet. 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,7 +9,7 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
 
   allowlist:
-    # remove groups as appropriate to give the minimum access required:
+    # remove groups as appropriate to give the minimum ingress access required:
     #   digital_staff_and_mojo: devices on the MoJ network
     #   moj_cloud_platform: services on Cloud Platform
     groups:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -4,17 +4,28 @@
 generic-service:
   ingress:
     host: template-kotlin.hmpps.service.justice.gov.uk
+    # modsecurity_enabled: true
 
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
-
+ 
   allowlist:
-    # remove groups as appropriate to give the minimum ingress access required:
+    # Configure groups as appropriate to give the minimum ingress access required:
     #   digital_staff_and_mojo: devices on the MoJ network
     #   moj_cloud_platform: services on Cloud Platform
+    # Other IP allowlist groups are here: 
+    # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
+
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform
+
+  # NOTE: Removing ALL allowlist groups will make the application accessible from the internet. 
+  #       If you are intending to do this, please ensure you uncomment the 'modsecurity_enabled=true' 
+  #       entry in the ingress above. This will enable WAF protection of the endpoint. You will need 
+  #       to configure modsecurity rules to suit your needs. Further information can be found here:
+  #       https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#modsecurity-web-application-firewall
+
 
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,7 +9,9 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
 
   allowlist:
-    # modify these to give the least access required
+    # remove groups as appropriate to give the minimum access required:
+    #   digital_staff_and_mojo: devices on the MoJ network
+    #   moj_cloud_platform: services on Cloud Platform
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform


### PR DESCRIPTION
This is to complete some work that Kristian did ages ago to give better granularity between MOJO network and Cloud Platforms.
Obviously this has security benefits (if developers choose to take it up).

There's some words around the use of allowlists / modsec.